### PR TITLE
Runtime node changes

### DIFF
--- a/Client/App.py
+++ b/Client/App.py
@@ -119,7 +119,7 @@ def add_node(sender, app, u):
             for k, v in component.parameters.items():
                 v_filtered = v
                 show_input = True
-                if capture != "":
+                if capture != "" and v[0]!="choice_propagate":
                     clause = v[1]
                     v_filtered = v[:1] + v[2:]
                     if clause != capture and clause != "shared":

--- a/Client/App.py
+++ b/Client/App.py
@@ -94,9 +94,12 @@ def choice_propagate(sender, app, u):
     component_dict = u[1][1].parameters
     children = dpg.get_item_children(dpg.get_item_children(u[0])[1][0])[1]
     for group in children:
-        text = dpg.get_item_label(dpg.get_item_children(group)[1][0])
+        field=dpg.get_item_children(group)[1]
+        text = dpg.get_item_label(field[0])
         v = component_dict[text]
-        if v[0] == "choice_propagate" or v[1] == "shared":
+        if v[0] == "choice_propagate" and group>sender:
+             break
+        if v[0] == "choice_propagate" or v[1] == "shared" or group<sender:
             continue
         elif (v[1] != app):
             dpg.hide_item(group)
@@ -124,7 +127,14 @@ def add_node(sender, app, u):
                 if v_filtered[0] == "choice_propagate":
                     with dpg.group(xoffset=120, horizontal=True):
                         dpg.add_text(k, label=k)
-                        dpg.add_combo(v_filtered[1:], width=150, default_value=v_filtered[2], user_data=[node_id, u],
+                        if k == "comparator":
+                            vi = []
+                            for id, i in enumerate(v_filtered[1:]):
+                                vi.append(comparator_dict[i])
+                            dpg.add_combo(vi, width=150, default_value=vi[0], user_data=[node_id, u],
+                                      callback=choice_propagate)
+                        else:
+                            dpg.add_combo(v_filtered[1:], width=150, default_value=v_filtered[2], user_data=[node_id, u],
                                       callback=choice_propagate)
                         capture = v_filtered[2]
                 elif v_filtered[0] == "float":

--- a/Client/App.py
+++ b/Client/App.py
@@ -90,43 +90,71 @@ def delink_callback(sender, app_data):
     dpg.delete_item(app_data)
 
 
+def choice_propagate(sender, app, u):
+    component_dict = u[1][1].parameters
+    children = dpg.get_item_children(dpg.get_item_children(u[0])[1][0])[1]
+    for group in children:
+        text = dpg.get_item_label(dpg.get_item_children(group)[1][0])
+        v = component_dict[text]
+        if v[0] == "choice_propagate" or v[1] == "shared":
+            continue
+        elif (v[1] != app):
+            dpg.hide_item(group)
+        else:
+            dpg.show_item(group)
+
+
 def add_node(sender, app, u):
     pos_x = dpg.get_item_pos("popup")[0] + scroll_add[0]
     pos_y = dpg.get_item_pos("popup")[1] + scroll_add[1]
-    with dpg.node(label=u[0], pos=[pos_x, pos_y], parent="node_editor"):
+    with dpg.node(label=u[0], pos=[pos_x, pos_y], parent="node_editor") as node_id:
         component = u[1]
         with dpg.node_attribute():
 
             # handle parameters generation
+            capture = ""
             for k, v in component.parameters.items():
-                if v[0] == "float":
+                v_filtered = v
+                show_input = True
+                if capture != "":
+                    clause = v[1]
+                    v_filtered = v[:1] + v[2:]
+                    if clause != capture and clause != "shared":
+                        show_input = False
+                if v_filtered[0] == "choice_propagate":
                     with dpg.group(xoffset=120, horizontal=True):
+                        dpg.add_text(k, label=k)
+                        dpg.add_combo(v_filtered[1:], width=150, default_value=v_filtered[2], user_data=[node_id, u],
+                                      callback=choice_propagate)
+                        capture = v_filtered[2]
+                elif v_filtered[0] == "float":
+                    with dpg.group(xoffset=120, horizontal=True, show=show_input):
                         dpg.add_text(k, label=k)
                         dpg.add_input_text(width=150, default_value="0")
-                elif v[0] == "vec2f":
+                elif v_filtered[0] == "vec2f":
 
-                    with dpg.group(xoffset=120, horizontal=True):
+                    with dpg.group(xoffset=120, horizontal=True, show=show_input):
                         dpg.add_text(k, label=k)
                         dpg.add_input_floatx(size=2, width=150, default_value=(0, 0))
-                elif v[0] == "choice":
-                    with dpg.group(xoffset=120, horizontal=True):
+                elif v_filtered[0] == "choice":
+                    with dpg.group(xoffset=120, horizontal=True, show=show_input):
                         dpg.add_text(k, label=k)
                         if k == "comparator":
                             vi = []
-                            for id, i in enumerate(v[1:]):
+                            for id, i in enumerate(v_filtered[1:]):
                                 vi.append(comparator_dict[i])
                             dpg.add_combo(vi, width=150, default_value=vi[0])
                         else:
-                            dpg.add_combo(v[1:], width=150, default_value=v[1])
+                            dpg.add_combo(v_filtered[1:], width=150, default_value=v_filtered[1])
 
-
-                elif v[0] == "color":
-                    with dpg.group():
+                elif v_filtered[0] == "color":
+                    with dpg.group(show=show_input):
                         dpg.add_text(k, label=k)
                         dpg.add_color_picker(width=200, height=200)
 
         with dpg.node_attribute(attribute_type=dpg.mvNode_Attr_Output):
             pass
+    return node_id
 
 
 def parse_components(path):

--- a/Client/components.json
+++ b/Client/components.json
@@ -1,11 +1,11 @@
 {
   "Size":{
-    "unit": ["choice","pixels","kb","cm"],
-    "pixels":["vec2f"],
-    "kb": ["float"],
-    "cm": ["vec2f"],
-    "comparator": ["choice",">",">=","<","<=","=="],
-    "threshold": ["float"]
+    "unit": ["choice_propagate","pixels","kb","cm"],
+    "pixels":["vec2f","pixels"],
+    "kb": ["float","kb"],
+    "cm": ["float","cm"],
+    "comparator": ["choice","shared",">",">=","<","<=","=="],
+    "threshold": ["float","shared"]
   },
 
   "Colors": {

--- a/Client/components.json
+++ b/Client/components.json
@@ -4,8 +4,8 @@
     "pixels":["vec2f","pixels"],
     "kb": ["float","kb"],
     "cm": ["vec2f","cm"],
-    "comparator": ["choice","shared",">",">=","<","<=","=="],
-    "threshold": ["float","shared"]
+    "comparator": ["choice_propagate",">",">=","<","<=","=="],
+    "threshold": ["float","equal"]
   },
 
   "Colors": {

--- a/Client/components.json
+++ b/Client/components.json
@@ -3,7 +3,7 @@
     "unit": ["choice_propagate","pixels","kb","cm"],
     "pixels":["vec2f","pixels"],
     "kb": ["float","kb"],
-    "cm": ["float","cm"],
+    "cm": ["vec2f","cm"],
     "comparator": ["choice","shared",">",">=","<","<=","=="],
     "threshold": ["float","shared"]
   },


### PR DESCRIPTION
PR introduces new system for the runtime visual changes to the nodes. 

- New json field- "choice_propagate" propagates choices to all the fields below. 
- All the later fields have to contain(after the type) the string value at which they are allowed to render. 
- "shared" parameter can be used to ignore the rendering condition. 
- Lastly, yes... this system is generic and will work for all the node types as long as their structure follows the guidelines.

![image](https://user-images.githubusercontent.com/52073715/165166849-7489d001-4f80-466b-84ee-86a917bbd76f.png)
![image](https://user-images.githubusercontent.com/52073715/165167323-2daf776a-4cfa-48d9-965d-358f3bfc999f.png)
